### PR TITLE
Add vote tally

### DIFF
--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -98,6 +98,7 @@ class VotingActivity : AppCompatActivity() {
         input.hint = "p != np"
         builder.setView(input)
 
+        // PositiveButton is always the rightmost button
         builder.setPositiveButton("Create") { _, _ ->
             val proposal = input.text.toString()
 
@@ -111,7 +112,8 @@ class VotingActivity : AppCompatActivity() {
             printShortToast("Voting procedure started")
         }
 
-        builder.setNegativeButton("Cancel") { dialog, _ ->
+        // NeutralButton is always the leftmost button
+        builder.setNeutralButton("Cancel") { dialog, _ ->
             dialog.cancel()
         }
 
@@ -135,22 +137,26 @@ class VotingActivity : AppCompatActivity() {
                 "proper JSON in its message field: ${block.transaction["message"]}."
         }
 
+        // Show vote subject and its proposer
         builder.setMessage(Html.fromHtml("<big>\"" + voteSubject + "\"</big>" +
             "<br><br>" +
             "<i><small>Proposed by: " +
             defaultCryptoProvider.keyFromPublicBin(block.publicKey) +
             "</small></i>", Html.FROM_HTML_MODE_LEGACY))
 
+        // PositiveButton is always the rightmost button
         builder.setPositiveButton("YES") { _, _ ->
             vh.respondToVote(true, block)
             printShortToast("You voted: YES")
         }
 
+        // NegativeButton is always second-from-right button
         builder.setNegativeButton("NO") { _, _ ->
             vh.respondToVote(false, block)
             printShortToast("You voted: NO")
         }
 
+        // NeutralButton is always the leftmost button
         builder.setNeutralButton("CANCEL") { dialog, _ ->
             printShortToast("No vote was cast")
             dialog.cancel()
@@ -163,6 +169,9 @@ class VotingActivity : AppCompatActivity() {
         showTally(voteSubject, block)
     }
 
+    /**
+     * Count votes and show tally
+     */
     fun showTally(voteSubject: String, block: TrustChainBlock) {
         val peers: MutableList<PublicKey> = ArrayList()
         peers.addAll(community.getPeers().map { it.publicKey })

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -137,12 +137,18 @@ class VotingActivity : AppCompatActivity() {
                 "proper JSON in its message field: ${block.transaction["message"]}."
         }
 
-        // Show vote subject and its proposer
+        // Get tally values
+        val tally = getTally(voteSubject, block)
+
+        // Show vote subject, proposer and current tally
         builder.setMessage(Html.fromHtml("<big>\"" + voteSubject + "\"</big>" +
             "<br><br>" +
             "<i><small>Proposed by: " +
             defaultCryptoProvider.keyFromPublicBin(block.publicKey) +
-            "</small></i>", Html.FROM_HTML_MODE_LEGACY))
+            "</small></i>" +
+            "<br><br>" +
+            "<i><small>Current tally: <br>" + "Yes: " + tally.first + " | No: " + tally.second + "</small></i>",
+            Html.FROM_HTML_MODE_LEGACY))
 
         // PositiveButton is always the rightmost button
         builder.setPositiveButton("YES") { _, _ ->
@@ -165,19 +171,16 @@ class VotingActivity : AppCompatActivity() {
         builder.setCancelable(true)
 
         builder.show()
-
-        showTally(voteSubject, block)
     }
 
     /**
-     * Count votes and show tally
+     * Count votes and return tally
      */
-    fun showTally(voteSubject: String, block: TrustChainBlock) {
+    fun getTally(voteSubject: String, block: TrustChainBlock): Pair<Int, Int> {
         val peers: MutableList<PublicKey> = ArrayList()
         peers.addAll(community.getPeers().map { it.publicKey })
         peers.add(community.myPeer.publicKey)
-        val tally = vh.countVotes(peers, voteSubject, block.publicKey)
-        printShortToast("Yes votes: ${tally.first}. No votes: ${tally.second}.")
+        return vh.countVotes(peers, voteSubject, block.publicKey)
     }
 
     /**

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -159,6 +159,16 @@ class VotingActivity : AppCompatActivity() {
         builder.setCancelable(true)
 
         builder.show()
+
+        showTally(voteSubject, block)
+    }
+
+    fun showTally(voteSubject: String, block: TrustChainBlock) {
+        val peers: MutableList<PublicKey> = ArrayList()
+        peers.addAll(community.getPeers().map { it.publicKey })
+        peers.add(community.myPeer.publicKey)
+        val tally = vh.countVotes(peers, voteSubject, block.publicKey)
+        printShortToast("Yes votes: ${tally.first}. No votes: ${tally.second}.")
     }
 
     /**


### PR DESCRIPTION
Vote tally is now shown at the bottom of the screen when a proposal is clicked (see image). Suggestions for showing this tally at other locations are welcome.

The kotlin-ipv8 submodule is also update to the latest version in this PR. No [spamming of linting errors](https://github.com/Tribler/kotlin-ipv8/pull/17) anymore 🎉 

![afbeelding](https://user-images.githubusercontent.com/23723475/79395859-ddac0f80-7f7a-11ea-82a4-f6459825b300.png)
