### PR TITLE
Voting mode toggle

### DIFF
--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import android.text.Html
 import android.view.LayoutInflater
 import android.widget.EditText
+import android.widget.Switch
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -97,6 +99,22 @@ class VotingActivity : AppCompatActivity() {
             .setView(dialogView)
             .setTitle("Initiate vote on proposal")
 
+        val switch = dialogView.findViewById<Switch>(R.id.votingModeToggle)
+        val switchLabel = dialogView.findViewById<TextView>(R.id.votingMode)
+        switchLabel.text = getString(R.string.yes_no_mode)
+        var votingMode: votingMode
+
+        switch.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                switchLabel.text = getString(R.string.threshold_mode)
+                votingMode = VotingActivity.votingMode.YESNO
+            } else {
+                switchLabel.text = getString(R.string.yes_no_mode)
+                votingMode = VotingActivity.votingMode.THRESHOLD
+            }
+            printShortToast(votingMode.toString())
+        }
+
         builder.setPositiveButton("Create") { _, _ ->
 
             val proposal = dialogView.findViewById<EditText>(R.id.proposalInput).text.toString()
@@ -107,7 +125,7 @@ class VotingActivity : AppCompatActivity() {
             peers.add(community.myPeer.publicKey)
 
             // Start voting procedure
-            vh.startVote(proposal, peers)
+            vh.startVote(proposal, peers) //TODO make use of votingMode variable
             printShortToast("Proposal has been created")
         }
 
@@ -261,5 +279,12 @@ class VotingActivity : AppCompatActivity() {
         if (displayAllVotes) return true
         val votePair = vh.castedByPeer(block, community.myPeer.publicKey)
         return votePair == Pair(0, 0)
+    }
+
+    /**
+     * Helper enum
+     */
+    enum class votingMode {
+        YESNO, THRESHOLD
     }
 }

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -124,7 +124,7 @@ class VotingActivity : AppCompatActivity() {
             peers.add(community.myPeer.publicKey)
 
             // Start voting procedure
-            vh.startVote(proposal, peers) //TODO make use of votingMode variable
+            vh.startVote(proposal, peers) // TODO make use of votingMode variable
             printShortToast("Proposal has been created")
         }
 

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -13,7 +13,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.activity_main_voting.*
-import kotlinx.android.synthetic.main.initiate_dialog.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import nl.tudelft.ipv8.android.IPv8Android
@@ -102,15 +101,15 @@ class VotingActivity : AppCompatActivity() {
         val switch = dialogView.findViewById<Switch>(R.id.votingModeToggle)
         val switchLabel = dialogView.findViewById<TextView>(R.id.votingMode)
         switchLabel.text = getString(R.string.yes_no_mode)
-        var votingMode: votingMode
+        var votingMode: VotingMode
 
         switch.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
                 switchLabel.text = getString(R.string.threshold_mode)
-                votingMode = VotingActivity.votingMode.YESNO
+                votingMode = VotingMode.YESNO
             } else {
                 switchLabel.text = getString(R.string.yes_no_mode)
-                votingMode = VotingActivity.votingMode.THRESHOLD
+                votingMode = VotingMode.THRESHOLD
             }
             printShortToast(votingMode.toString())
         }
@@ -279,12 +278,5 @@ class VotingActivity : AppCompatActivity() {
         if (displayAllVotes) return true
         val votePair = vh.castedByPeer(block, community.myPeer.publicKey)
         return votePair == Pair(0, 0)
-    }
-
-    /**
-     * Helper enum
-     */
-    enum class votingMode {
-        YESNO, THRESHOLD
     }
 }

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingMode.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingMode.kt
@@ -1,0 +1,8 @@
+package nl.tudelft.trustchain.voting
+
+/**
+ * Helper enum
+ */
+enum class VotingMode {
+    YESNO, THRESHOLD
+}

--- a/voting/src/main/res/layout/initiate_dialog.xml
+++ b/voting/src/main/res/layout/initiate_dialog.xml
@@ -17,6 +17,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginTop="10dp"
         android:orientation="horizontal">
 
         <Switch

--- a/voting/src/main/res/layout/initiate_dialog.xml
+++ b/voting/src/main/res/layout/initiate_dialog.xml
@@ -14,4 +14,21 @@
         android:layout_marginRight="10dp"
         android:hint="@string/p_np" />
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <Switch
+            android:id="@+id/votingModeToggle"
+            android:layout_width="51dp"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/votingMode"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+    </LinearLayout>
+
 </LinearLayout>

--- a/voting/src/main/res/values/strings.xml
+++ b/voting/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="new_proposals">New Proposals</string>
     <string name="all_proposals">All Proposals</string>
     <string name="p_np">e.g. P != NP</string>
-    <string name="yes_no_mode">Yes / No voting</string>
+    <string name="yes_no_mode">Yes / No mode</string>
     <string name="threshold_mode">Threshold mode</string>
 
 </resources>

--- a/voting/src/main/res/values/strings.xml
+++ b/voting/src/main/res/values/strings.xml
@@ -5,5 +5,7 @@
     <string name="new_proposals">New Proposals</string>
     <string name="all_proposals">All Proposals</string>
     <string name="p_np">e.g. P != NP</string>
+    <string name="yes_no_mode">Yes / No voting</string>
+    <string name="threshold_mode">Threshold mode</string>
 
 </resources>


### PR DESCRIPTION
As the title suggests, this adds a toggle to the propose dialog that allows the user to switch between the modes `Yes / No voting` and `Threshold voting`. Do note that threshold voting is not implemented yet, but this will come in useful during the development of that. It is linked in the backend to the variable `votingMode (enum)`. This can be passed along the `startVote` method, see the TODO

![image](https://user-images.githubusercontent.com/17474698/79636140-def55c00-8175-11ea-823e-40bb02e7d7ec.png)
![image](https://user-images.githubusercontent.com/17474698/79636143-e4eb3d00-8175-11ea-8fee-c6045676c58f.png)
