### PR TITLE
No key fix

### DIFF
--- a/common/src/main/java/nl/tudelft/trustchain/common/util/VotingHelper.kt
+++ b/common/src/main/java/nl/tudelft/trustchain/common/util/VotingHelper.kt
@@ -245,7 +245,7 @@ class VotingHelper(
     }
 
     /**
-     * Checks if a block possesses a specific attribute, without retiring it explicitly
+     * Checks if a block possesses a specific attribute, without retrieving it explicitly
      */
     private fun hasVoteBlockAttributeByKey(block: TrustChainBlock, key: String): Boolean {
 

--- a/common/src/main/java/nl/tudelft/trustchain/common/util/VotingHelper.kt
+++ b/common/src/main/java/nl/tudelft/trustchain/common/util/VotingHelper.kt
@@ -271,27 +271,10 @@ class VotingHelper(
      * Return the string value for a JSON tag in a voting block.
      */
     private fun getVoteBlockAttributesByKey(block: TrustChainBlock, key: String): String {
-
-        // Skip all blocks which are not voting blocks
-        // and don't have a 'message' field in their transaction.
-        if (block.type != votingBlock || !block.transaction.containsKey("message")) {
-            handleInvalidVote(
-                block,
-                "Block was not a voting block or did not contain a 'message' field in its transaction."
-            )
+        if (hasVoteBlockAttributeByKey(block, key)) {
+            return JSONObject(block.transaction["message"].toString()).get(key).toString()
         }
-
-        val voteJSON = try {
-            JSONObject(block.transaction["message"].toString())
-        } catch (e: JSONException) {
-            handleInvalidVote(block, "Voting block did not contain proper JSON.")
-        }
-
-        try {
-            return voteJSON.get(key).toString()
-        } catch (e: JSONException) {
-            handleInvalidVote(block, "Voting JSON did not have a value for key '$key'.")
-        }
+        handleInvalidVote(block, "Voting JSON did not have a value for key '$key'.")
     }
 
     /**

--- a/common/src/main/java/nl/tudelft/trustchain/common/util/VotingHelper.kt
+++ b/common/src/main/java/nl/tudelft/trustchain/common/util/VotingHelper.kt
@@ -110,12 +110,8 @@ class VotingHelper(
                 continue
             }
 
-            try {
-                getVoteBlockAttributesByKey(it, "VOTE_REPLY")
-            } catch (e: Exception) {
-                // Block is the initial vote proposal because it does not have a VOTE_REPLY field.
-                continue
-            }
+            // If no vote_reply present, we are dealing with the proposal block
+            if (!hasVoteBlockAttributeByKey(it, "VOTE_REPLY")) continue
 
             // Check whether the voter is in voting list.
             @SuppressLint
@@ -127,7 +123,7 @@ class VotingHelper(
             }
 
             // Add the votes, or assume a malicious vote if it is not YES or NO.
-            when (getVoteBlockAttributesByKey(it, "VOTE_REPLY")) {
+            when (val voteReply = getVoteBlockAttributesByKey(it, "VOTE_REPLY")) {
                 "YES" -> {
                     yesCount++
                     votes.add(it.publicKey.contentToString())
@@ -136,7 +132,10 @@ class VotingHelper(
                     noCount++
                     votes.add(it.publicKey.contentToString())
                 }
-                else -> handleInvalidVote(it, "Vote was not 'YES' or 'NO' but: '${getVoteBlockAttributesByKey(it, "VOTE_REPLY")}'.")
+                else -> handleInvalidVote(
+                    it,
+                    "Vote was not 'YES' or 'NO' but: '$voteReply}'."
+                )
             }
         }
 
@@ -172,7 +171,10 @@ class VotingHelper(
 
             val hexKey = string.toString().hexToBytes()
             if (!defaultCryptoProvider.isValidPublicBin(hexKey)) {
-                handleInvalidVote(block, "A public key in the voter list was not valid. Its value was: $string.")
+                handleInvalidVote(
+                    block,
+                    "A public key in the voter list was not valid. Its value was: $string."
+                )
             }
 
             val key = defaultCryptoProvider.keyFromPublicBin(hexKey)
@@ -187,7 +189,10 @@ class VotingHelper(
      * threshold, or a yes/no vote has received votes from all eligible voters.
      */
     fun votingIsComplete(block: TrustChainBlock, threshold: Int = -1): Boolean {
-        return getVoteProgressStatus(block, threshold) == 100 || getVoteProgressStatus(block, threshold) == -1
+        return getVoteProgressStatus(block, threshold) == 100 || getVoteProgressStatus(
+            block,
+            threshold
+        ) == -1
     }
 
     /**
@@ -209,7 +214,10 @@ class VotingHelper(
 
         val hexKey = proposerKey.hexToBytes()
         if (!defaultCryptoProvider.isValidPublicBin(hexKey)) {
-            handleInvalidVote(block, "The proposer key from the block was not valid. Its value was: $proposerKey.")
+            handleInvalidVote(
+                block,
+                "The proposer key from the block was not valid. Its value was: $proposerKey."
+            )
         }
 
         val key = defaultCryptoProvider.keyFromPublicBin(hexKey)
@@ -237,6 +245,29 @@ class VotingHelper(
     }
 
     /**
+     * Checks if a block possesses a specific attribute, without retiring it explicitly
+     */
+    private fun hasVoteBlockAttributeByKey(block: TrustChainBlock, key: String): Boolean {
+
+        // Skip all blocks which are not voting blocks
+        // and don't have a 'message' field in their transaction.
+        if (block.type != votingBlock || !block.transaction.containsKey("message")) {
+            handleInvalidVote(
+                block,
+                "Block was not a voting block or did not contain a 'message' field in its transaction."
+            )
+        }
+
+        val voteJSON = try {
+            JSONObject(block.transaction["message"].toString())
+        } catch (e: JSONException) {
+            handleInvalidVote(block, "Voting block did not contain proper JSON.")
+        }
+
+        return voteJSON.has(key)
+    }
+
+    /**
      * Return the string value for a JSON tag in a voting block.
      */
     private fun getVoteBlockAttributesByKey(block: TrustChainBlock, key: String): String {
@@ -244,7 +275,10 @@ class VotingHelper(
         // Skip all blocks which are not voting blocks
         // and don't have a 'message' field in their transaction.
         if (block.type != votingBlock || !block.transaction.containsKey("message")) {
-            handleInvalidVote(block, "Block was not a voting block or did not contain a 'message' field in its transaction.")
+            handleInvalidVote(
+                block,
+                "Block was not a voting block or did not contain a 'message' field in its transaction."
+            )
         }
 
         val voteJSON = try {
@@ -264,8 +298,10 @@ class VotingHelper(
      * Throw an exception when an invalid vote is encountered.
      */
     private fun handleInvalidVote(block: TrustChainBlock, errorType: String): Nothing {
-        Log.e("vote_debug", "Encountered an invalid voting block with ID ${block.blockId}." +
-            "The reason for invalidity was: $errorType")
+        Log.e(
+            "vote_debug", "Encountered an invalid voting block with ID ${block.blockId}." +
+                "The reason for invalidity was: $errorType"
+        )
         throw Exception(errorType)
     }
 }

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/BlockListAdapter.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/BlockListAdapter.kt
@@ -13,12 +13,12 @@ import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
 import nl.tudelft.trustchain.common.util.VotingHelper
 import org.json.JSONObject
 
-class blockListAdapter(
+class BlockListAdapter(
     private val myDataset: List<TrustChainBlock>,
     private val vh: VotingHelper
 ) :
 
-    RecyclerView.Adapter<blockListAdapter.MyViewHolder>() {
+    RecyclerView.Adapter<BlockListAdapter.MyViewHolder>() {
 
     var onItemClick: ((TrustChainBlock) -> Unit)? = null
 
@@ -58,7 +58,7 @@ class blockListAdapter(
         try {
             val bar = holder.progressBar
             var thresholdNotMade = false
-            var progressValue = vh.getVoteProgressStatus(myDataset[position], 1)
+            val progressValue = vh.getVoteProgressStatus(myDataset[position], 1)
 
             if (progressValue == -1) {
                 bar.progress = 100

--- a/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
+++ b/voting/src/main/java/nl/tudelft/trustchain/voting/VotingActivity.kt
@@ -30,7 +30,7 @@ class VotingActivity : AppCompatActivity() {
 
     private lateinit var vh: VotingHelper
     private lateinit var community: VotingCommunity
-    private lateinit var adapter: blockListAdapter
+    private lateinit var adapter: BlockListAdapter
     private lateinit var tch: TrustChainHelper
 
     private var voteProposals: MutableList<TrustChainBlock> = mutableListOf()
@@ -71,7 +71,7 @@ class VotingActivity : AppCompatActivity() {
 
         blockList.layoutManager = LinearLayoutManager(this)
 
-        adapter = blockListAdapter(voteProposals, vh)
+        adapter = BlockListAdapter(voteProposals, vh)
 
         adapter.onItemClick = { block ->
             try {


### PR DESCRIPTION
As mentioned in issue #35 , a lot of errors where logged when they shouldn't. The reason for this is that a getter was used to check if something was present. If a field was not present, it would produce an error. So I've written a method that checks if this field is present, and returns an appropriate boolean value. This method is now also used by the getter before attempting to get a field.

The other changes you can see are android studio reformat suggestions.

closes #35 